### PR TITLE
Window manip

### DIFF
--- a/CLI-Game/CLI-Game.vcxproj
+++ b/CLI-Game/CLI-Game.vcxproj
@@ -134,7 +134,6 @@
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\CLGEngine\Graphics\Render.cpp" />
     <ClCompile Include="src\CLGEngine\Time.cpp" />
-    <ClCompile Include="src\CLGEngine\CORE\Utility.cpp" />
     <ClCompile Include="src\CLGEngine\CORE\MainWindow.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/CLI-Game/CLI-Game.vcxproj.filters
+++ b/CLI-Game/CLI-Game.vcxproj.filters
@@ -36,9 +36,6 @@
     <ClCompile Include="src\CLGEngine\Time.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\CLGEngine\CORE\Utility.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="src\CLGEngine\CORE\MainWindow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/CLI-Game/src/CLGEngine/CORE/Utility.h
+++ b/CLI-Game/src/CLGEngine/CORE/Utility.h
@@ -4,7 +4,36 @@ namespace CLGEngine {
 	namespace CORE {
 		template<typename T>
 		struct Vector2 {
+			// TODO: REstrict T to numeric types (?)
+			//	*(?) May not be needed unless we allow for type casting.
+			// -> static_assert();
 			T x, y;
+			Vector2<T> operator+(Vector2<T> const& vec) {
+				Vector2<T> sum;
+				sum.x = x + vec.x;
+				sum.y = y + vec.y;
+				return sum;
+			}
+			Vector2<T> operator-(Vector2<T> const& vec) {
+				Vector2<T> diff;
+				diff.x = x - vec.x;
+				diff.y = y - vec.y;
+				return diff;
+			}
+			Vector2<T> operator*(T factor) {
+				Vector2<T> product;
+				product.x = factor * x;
+				product.y = factor * y;
+				return product;
+			}
+			T dot(Vector2<T> factor) {
+				T product = (factor.x * x)
+						  + (factor.y * y);
+				return product;
+			}
+			//TODO: would be nice to find a way to make type casting work on this.
+			// Something in the lines of (float)Vector2<int>.
+			// For now: explicitly create a new temp Vector2 with type casted vars.
 		};
 	}
 }

--- a/CLI-Game/src/CLGEngine/Entity.cpp
+++ b/CLI-Game/src/CLGEngine/Entity.cpp
@@ -15,7 +15,7 @@ namespace CLGEngine {
 		size.y = 1;
 	}
 
-	Entity::Entity(float x, float y, int width, int height) {
+	Entity::Entity(float x, float y, float width, float height) {
 		this->position.x = x;
 		this->position.y = y;
 		this->size.x = width;

--- a/CLI-Game/src/CLGEngine/Entity.h
+++ b/CLI-Game/src/CLGEngine/Entity.h
@@ -11,7 +11,7 @@ namespace CLGEngine {
 		CORE::Vector2<float> position;
 		CORE::Vector2<float> size;
 		Entity();
-		Entity(float x, float y, int width, int height);
+		Entity(float x, float y, float width, float height);
 		virtual void Move(float x, float y);
 	};
 }

--- a/CLI-Game/src/main.cpp
+++ b/CLI-Game/src/main.cpp
@@ -73,7 +73,7 @@ int main()
         
         // -- Begin window resizing tests
 
-        int windowSpeed = 10;
+        int windowSpeed = 1;
 
         // Grow Window
         if (Input::Input::GetKeyDown(Input::KeyCode::J)) {


### PR DESCRIPTION
Window Manipulation is being a abandoned now, as I shift into a simpler, less ambitious project.
The decision was made due to several road blocks that piled on top of each other that are PREREQUISITES for the game. Simpler games with simpler systems will help build out these prerequisites in a way that is more manageable and easier to fight off imposter syndrome.

For window manipulation current bugs are as follows:
- Grabbing the "main" program window is done by grabbing the "top-most" window
  - This means, if the user clicks on accidentally, or purposefully on another window, the app may grab another program's window and manipulate it.
  - Also, it is unreliable. At times no windows will be manipulated.
- Screen buffer is bugged - unsure if Windows bug or mine - where buffer size is immutable; Cannot be set, cannot be changed.
  - This is a huge issue when the game relies on the image buffer to constantly change as the windows resize.
  
For the sake of progress and keeping my sanity. These issues will be put in the back burner, and hopefully, maybe be revisited in the future.