### PR TITLE
fixed text Block over and underflowing. 

### DIFF
--- a/src/CLGEngine/Components/Renderers/Renderer.cpp
+++ b/src/CLGEngine/Components/Renderers/Renderer.cpp
@@ -11,13 +11,18 @@ namespace CLGEngine {
 
 Renderer::Renderer(CLGEngine::Entity* ent)
 : Component(ent) 
-, _screen(Game::GetGameInstance()->mainWindow.screen) 
-, block(Block(ent->rect)){
+, _screen(Game::GetGameInstance()->mainWindow.screen)
+, block (Block(ent->rect)) {
 	_screen->AddToRenderQueue(&block);
 }
 
 Renderer::~Renderer() {
 	_screen->RemoveFromRenderQueue(&block);
+}
+
+
+void Renderer:: CreateNewBlock(Rect rect){
+	block = Block(rect);
 }
 
 // Warn: if we - for whatever reason - need to change this at runtime,

--- a/src/CLGEngine/Components/Renderers/Renderer.h
+++ b/src/CLGEngine/Components/Renderers/Renderer.h
@@ -20,6 +20,8 @@ private:
 	Screen* _screen;
 protected:
 	bool _squareCells;
+
+	void CreateNewBlock(Rect rect);
 public:
 	Block block;
 	CHAR_INFO material;

--- a/src/CLGEngine/Components/Renderers/TextRenderer.cpp
+++ b/src/CLGEngine/Components/Renderers/TextRenderer.cpp
@@ -14,10 +14,12 @@ TextRenderer::~TextRenderer(){
 
 void TextRenderer::SetText(std::string text){
     _text = text; 
-    float capacity = block.rect.size.x * block.rect.size.y;
+    float capacity = entity->rect.size.x * entity->rect.size.y;
     float textSize = text.size();
+    // BUG: It only shrinks, not stretch.
     if(textSize < capacity){
         capacity = text.size();
+        block.Resize({(int)capacity, 1}); // TODO: calculate y
     } else {
         // TODO: Notify user the text will be cut off
         //       IF autoSize is off.
@@ -27,7 +29,7 @@ void TextRenderer::SetText(std::string text){
 
     // Full Text Wrap, cut off on limit
     for(int i = 0; i < capacity; i++){
-        CHAR_INFO c = {text[i], WHITE};
+        CHAR_INFO c = {text[i], WHITE}; // TODO: Change WHITE to FontColor after testing
         block.dataArr[i] = c;
 
     }

--- a/src/CLGEngine/Graphics/Block.cpp
+++ b/src/CLGEngine/Graphics/Block.cpp
@@ -36,6 +36,6 @@ void Block::Resize(Vector2<int> size){
 
     delete dataArr; // This shouldn't be null, but check here if ther's an error.
     dataArr = new CHAR_INFO[size.x * size.y];
-    Fill(defaultMaterial);
+    Fill(defaultMaterial); // Do we want this here??
 }
 }


### PR DESCRIPTION
TextRenderer now references Entity's Rect for size.