### PR TITLE
Passthrough collider

### DIFF
--- a/src/CLGEngine/Components/Collider.cpp
+++ b/src/CLGEngine/Components/Collider.cpp
@@ -111,6 +111,7 @@ Collider* Collider::CheckCollisionPoint(Vector2<float> point){
           || point.y >= col->bounds.bottom
           || col == this)
         {
+            BroadcastHit(false, col);
             continue;
         }
 

--- a/src/CLGEngine/Components/Collider.cpp
+++ b/src/CLGEngine/Components/Collider.cpp
@@ -23,8 +23,7 @@ void Collider::BroadcastHit(bool wasHit, Collider* hit){
         hit->entity->OnCollision(this->entity);
         this->entity->OnCollision(hit->entity);
     }
-    // End broadcast (how do we do this?)
-    // We need to trigger this when we DONT BroadcastHit..
+    // End broadcast 
     if(inList && !wasHit){
         hit->entity->OnCollisionEnd(this->entity);
         this->entity->OnCollisionEnd(hit->entity);

--- a/src/CLGEngine/Components/Collider.h
+++ b/src/CLGEngine/Components/Collider.h
@@ -30,13 +30,10 @@ private:
     void UpdateBounds();
     void BroadcastHit(bool wasHit, Collider* hit);
     bool _isActive;
+    
     /// @brief The last and current collider this collider collided with.
     std::vector<Collider*> _hitColliders;
 public:
-
-    // TODO: Second part is a lie, we don't have an auto-phsycial interaciton system.
-    //          But we should, Make it.
-    
     /// @brief Determines if the object is solid. 
     /// Non-solid objects still emit hit events, but don't effect physical interactions.
     bool isSolid;

--- a/src/Game/Entities/Character.cpp
+++ b/src/Game/Entities/Character.cpp
@@ -130,7 +130,10 @@ void Character::Move(float momentum) {
     // TODO: Collisison should be universal. maybe on a Physics Engine update.
     CLGEngine::Vector2<float> nextCell = {nextXPosition, _position.y};
     CLGEngine::Collider* hit = _col->CheckCollisionPoint(nextCell);
-    if(_tileMap->GetTile((CLGEngine::Vector2<int>)nextCell) != '#' && hit == nullptr){
+    bool solidObject = 
+        (hit == nullptr) ? 
+        false : hit->isSolid;
+    if(_tileMap->GetTile((CLGEngine::Vector2<int>)nextCell) != '#' && !solidObject){
         _position += {momentum * _speed * CLGEngine::Time::deltaTime, 0};
         SnapRectToGrid();
     }
@@ -146,8 +149,11 @@ void Character::Jump(){
 
     CLGEngine::Vector2<float> nextCell = {nextPos.x, nextPos.y};
     CLGEngine::Collider* hit = _col->CheckCollisionPoint(nextCell);
+    bool solidObject = 
+        (hit == nullptr) ? 
+        false : hit->isSolid;
     if((_tileMap->GetTile((CLGEngine::Vector2<int>)nextCell) == '#'
-        || hit != nullptr
+        || solidObject
         || _position.y <= _groundLevel - jumpHeight
         ) 
         && vertMomentum == 1)

--- a/src/Game/Entities/Character.cpp
+++ b/src/Game/Entities/Character.cpp
@@ -66,7 +66,10 @@ void Character::Update(){
 #pragma region Jump/Gravity Logic
     CLGEngine::Vector2<float> belowCell = {_position.x, _position.y + 0.5f};
     CLGEngine::Collider* hit = _col->CheckCollisionPoint(belowCell);
-    _grounded = _tileMap->GetTile((CLGEngine::Vector2<int>)belowCell) == '#' || hit != nullptr;
+    bool solidGround = 
+        (hit == nullptr) ? 
+        false : hit->isSolid;  
+    _grounded = _tileMap->GetTile((CLGEngine::Vector2<int>)belowCell) == '#' || solidGround;
     
     if(_grounded){ 
         _groundLevel = belowCell.y;

--- a/src/Game/Entities/Switch.cpp
+++ b/src/Game/Entities/Switch.cpp
@@ -26,6 +26,7 @@ Switch::Switch(std::vector<Door*> doors)
             throw;
         }
     }
+    _col->isSolid = false;
     _doors = doors;
     _color = CODE_COLORS[code];
     material.Attributes |= CODE_COLORS[code];


### PR DESCRIPTION
Switch now works as intended

BUG: When jumping from switch, it is activating multiple times
- This maybe due to the multiple calls to the switch as the charatcer is jumping out and off teh switch
- [ ] Set a `Down` logic for the switch?
  - Only activates when the switch is "Up", only leaves "Down" possition `OnCollisionExcit()`